### PR TITLE
Customizable end parameter

### DIFF
--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -168,8 +168,8 @@ class TermSpark:
 
             setattr(self, position, pos)
 
-    def spark(self):
-        print(self.render())
+    def spark(self, end="\n"):
+        print(self.render(), end=end)
 
     def __repr__(self) -> str:
         return self.render()


### PR DESCRIPTION
```python
from termspark import TermSpark

termspark = TermSpark()
termspark.spark_left("LEFT")
termspark.spark_right("RIGHT")
termspark.set_separator('.')
termspark.spark(end="\r")
```