### PR TITLE
Force width

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,12 @@ You can print raw version wich is colors-code-free so you can print clean text i
 
     TermSpark().print_left('LEFT').print_right('RIGHT').set_separator('.').raw()
 ```
+
+### Force Width
+You can customize width instead of the default full terminal width.
+
+```python
+    from termspark.termspark import TermSpark
+
+    TermSpark().set_width(40).print_left("LEFT", "red").print_right("RIGHT", "blue").spark()
+```

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -12,6 +12,7 @@ from .structurer.structurer import Structurer
 
 class TermSpark:
     mode: str = "color"
+    width: int = 0
     left: Dict[str, str] = {}
     right: Dict[str, str] = {}
     center: Dict[str, str] = {}
@@ -118,6 +119,11 @@ class TermSpark:
 
         return self
 
+    def set_width(self, width: int):
+        self.width = width
+
+        return self
+
     def calculate_separator_length(self):
         colors_codes_length = self.calculate_colors_codes_length()
         content_length = 0
@@ -127,9 +133,7 @@ class TermSpark:
                 getattr(self, position), "painted_content"
             )
             content_length += len(painted_content)
-        self.separator_length = (
-            self.get_terminal_width() - content_length + colors_codes_length
-        )
+        self.separator_length = self.get_width() - content_length + colors_codes_length
 
     def calculate_colors_codes_length(self) -> int:
         colors_codes_length = 0
@@ -171,7 +175,14 @@ class TermSpark:
             width = os.get_terminal_size()[0]
         except OSError:
             width = 80
+
         return width
+
+    def get_width(self) -> int:
+        if self.width == 0:
+            self.width = self.get_terminal_width()
+
+        return self.width
 
     def render(self) -> str:
         self.paint_content()

--- a/tests/termspark_return_test.py
+++ b/tests/termspark_return_test.py
@@ -281,3 +281,9 @@ class TestTermsparkReturn:
 
         terminal_width = termspark.get_terminal_width()
         assert str(termspark) == "." * (terminal_width - len("\x1b"))
+
+    def test_force_width(self):
+        width = 100
+        termspark = TermSpark().set_width(width).line(".")
+
+        assert str(termspark) == "." * (width - len("\x1b"))

--- a/tests/width_force_test.py
+++ b/tests/width_force_test.py
@@ -1,0 +1,10 @@
+from termspark.termspark import TermSpark
+
+
+class TestForceWidth:
+    def test_force_width(self):
+        termspark = TermSpark().set_width(100).print_left("LEFT", "red")
+        termspark.raw()
+
+        assert termspark.get_width() == 100
+        assert termspark.width == 100


### PR DESCRIPTION
### Without Force Width
It will take all terminal width.
```python
from termspark.termspark import TermSpark

TermSpark().print_left("LEFT", "red").print_rightRIGHT", "blue").spark()
```
![image](https://github.com/faissaloux/termspark/assets/60013703/7438916a-1017-4473-9399-345c9d1424c0)

### With Force Width
It will take only the specified terminal width.
```python
from termspark.termspark import TermSpark

TermSpark().set_width(40).print_left("LEFT", "red").print_right("RIGHT", "blue").spark()
```
![image](https://github.com/faissaloux/termspark/assets/60013703/194149dd-d5c3-47a9-82fd-5a9e485125e3)
