### PR TITLE
Add ability to set max length for content

### DIFF
--- a/termspark/exceptions/maxLenNotSupported.py
+++ b/termspark/exceptions/maxLenNotSupported.py
@@ -1,0 +1,12 @@
+import termspark.termspark
+
+
+class MaxLenNotSupported(Exception):
+    def __init__(self, method: str):
+        self.method = method
+
+    def __str__(self):
+        message = termspark.TermSpark().print_left(
+            f"Max Length not supported for {self.method}, use spark_[position] instead!", "red"
+        )
+        return str(message)

--- a/termspark/exceptions/maxLenNotSupported.py
+++ b/termspark/exceptions/maxLenNotSupported.py
@@ -7,6 +7,7 @@ class MaxLenNotSupported(Exception):
 
     def __str__(self):
         message = termspark.TermSpark().print_left(
-            f"Max Length not supported for {self.method}, use spark_[position] instead!", "red"
+            f"Max Length not supported for {self.method}, use spark_[position] instead!",
+            "red",
         )
         return str(message)

--- a/termspark/exceptions/minNotReachedException.py
+++ b/termspark/exceptions/minNotReachedException.py
@@ -1,0 +1,13 @@
+import termspark.termspark
+
+
+class MinNotReachedException(Exception):
+    def __init__(self, var: str, min: int):
+        self.var = var
+        self.min = min
+
+    def __str__(self):
+        message = termspark.TermSpark().print_left(
+            f"{self.var} must be at least {self.min}!", "red"
+        )
+        return str(message)

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -3,10 +3,10 @@ from itertools import chain
 from typing import Dict, List, Optional
 
 from .exceptions.argCharsExceededException import ArgCharsExceededException
+from .exceptions.maxLenNotSupported import MaxLenNotSupported
+from .exceptions.minNotReachedException import MinNotReachedException
 from .exceptions.printerArgException import PrinterArgException
 from .exceptions.printerSparkerMixException import PrinterSparkerMixException
-from .exceptions.minNotReachedException import MinNotReachedException
-from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .helpers.existenceChecker import ExistenceChecker
 from .painter.painter import Painter
 from .structurer.structurer import Structurer
@@ -70,7 +70,7 @@ class TermSpark:
         self.spark_position("center", *contents)
 
         return self
-    
+
     def max_left(self, max: int):
         if "left" in self.printed:
             raise MaxLenNotSupported("print_left")
@@ -90,11 +90,11 @@ class TermSpark:
                 new_content.append(sentence)
                 chars_number -= len(sentence)
             elif len(sentence) == chars_number:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
             else:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
@@ -103,7 +103,7 @@ class TermSpark:
         self.left["highlight"] = self.left["highlight"][0:breakIndex]
 
         return self
-    
+
     def max_right(self, max: int):
         if "right" in self.printed:
             raise MaxLenNotSupported("print_right")
@@ -123,11 +123,11 @@ class TermSpark:
                 new_content.append(sentence)
                 chars_number -= len(sentence)
             elif len(sentence) == chars_number:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
             else:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
@@ -136,7 +136,7 @@ class TermSpark:
         self.right["highlight"] = self.right["highlight"][0:breakIndex]
 
         return self
-    
+
     def max_center(self, max: int):
         if "center" in self.printed:
             raise MaxLenNotSupported("print_center")
@@ -156,11 +156,11 @@ class TermSpark:
                 new_content.append(sentence)
                 chars_number -= len(sentence)
             elif len(sentence) == chars_number:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
             else:
-                new_content.append(sentence[0 : chars_number])
+                new_content.append(sentence[0:chars_number])
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -70,7 +70,7 @@ class TermSpark:
         self.spark_position("center", *contents)
 
         return self
-    
+
     def max_position(self, position: str, max: int):
         if position in self.printed:
             raise MaxLenNotSupported(f"print_{position}")
@@ -99,8 +99,12 @@ class TermSpark:
                 breakIndex = index + 1
 
         getattr(self, position)["content"] = new_content
-        getattr(self, position)["color"] = getattr(self, position)["color"][0:breakIndex]
-        getattr(self, position)["highlight"] = getattr(self, position)["highlight"][0:breakIndex]
+        getattr(self, position)["color"] = getattr(self, position)["color"][
+            0:breakIndex
+        ]
+        getattr(self, position)["highlight"] = getattr(self, position)["highlight"][
+            0:breakIndex
+        ]
 
     def max_left(self, max: int):
         self.max_position("left", max)

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -98,9 +98,9 @@ class TermSpark:
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
-        self.left["content"] = new_content
-        self.left["color"] = self.left["color"][0:breakIndex]
-        self.left["highlight"] = self.left["highlight"][0:breakIndex]
+        getattr(self, "left")["content"] = new_content
+        getattr(self, "left")["color"] = getattr(self, "left")["color"][0:breakIndex]
+        getattr(self, "left")["highlight"] = getattr(self, "left")["highlight"][0:breakIndex]
 
         return self
 
@@ -131,9 +131,9 @@ class TermSpark:
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
-        self.right["content"] = new_content
-        self.right["color"] = self.right["color"][0:breakIndex]
-        self.right["highlight"] = self.right["highlight"][0:breakIndex]
+        getattr(self, "right")["content"] = new_content
+        getattr(self, "right")["color"] = getattr(self, "right")["color"][0:breakIndex]
+        getattr(self, "right")["highlight"] = getattr(self, "right")["highlight"][0:breakIndex]
 
         return self
 
@@ -164,9 +164,9 @@ class TermSpark:
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
-        self.center["content"] = new_content
-        self.center["color"] = self.center["color"][0:breakIndex]
-        self.center["highlight"] = self.center["highlight"][0:breakIndex]
+        getattr(self, "center")["content"] = new_content
+        getattr(self, "center")["color"] = getattr(self, "center")["color"][0:breakIndex]
+        getattr(self, "center")["highlight"] = getattr(self, "center")["highlight"][0:breakIndex]
 
         return self
 

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -5,6 +5,8 @@ from typing import Dict, List, Optional
 from .exceptions.argCharsExceededException import ArgCharsExceededException
 from .exceptions.printerArgException import PrinterArgException
 from .exceptions.printerSparkerMixException import PrinterSparkerMixException
+from .exceptions.minNotReachedException import MinNotReachedException
+from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .helpers.existenceChecker import ExistenceChecker
 from .painter.painter import Painter
 from .structurer.structurer import Structurer
@@ -66,6 +68,105 @@ class TermSpark:
 
     def spark_center(self, *contents: List[str]):
         self.spark_position("center", *contents)
+
+        return self
+    
+    def max_left(self, max: int):
+        if "left" in self.printed:
+            raise MaxLenNotSupported("print_left")
+
+        if max < 1:
+            raise MinNotReachedException("max", 1)
+
+        chars_number = max
+        new_content = []
+        breakIndex = 0
+
+        for index, sentence in enumerate(self.left["content"]):
+            if chars_number <= 0:
+                break
+
+            if len(sentence) < chars_number:
+                new_content.append(sentence)
+                chars_number -= len(sentence)
+            elif len(sentence) == chars_number:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+            else:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+
+        self.left["content"] = new_content
+        self.left["color"] = self.left["color"][0:breakIndex]
+        self.left["highlight"] = self.left["highlight"][0:breakIndex]
+
+        return self
+    
+    def max_right(self, max: int):
+        if "right" in self.printed:
+            raise MaxLenNotSupported("print_right")
+
+        if max < 1:
+            raise MinNotReachedException("max", 1)
+
+        chars_number = max
+        new_content = []
+        breakIndex = 0
+
+        for index, sentence in enumerate(self.right["content"]):
+            if chars_number <= 0:
+                break
+
+            if len(sentence) < chars_number:
+                new_content.append(sentence)
+                chars_number -= len(sentence)
+            elif len(sentence) == chars_number:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+            else:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+
+        self.right["content"] = new_content
+        self.right["color"] = self.right["color"][0:breakIndex]
+        self.right["highlight"] = self.right["highlight"][0:breakIndex]
+
+        return self
+    
+    def max_center(self, max: int):
+        if "center" in self.printed:
+            raise MaxLenNotSupported("print_center")
+
+        if max < 1:
+            raise MinNotReachedException("max", 1)
+
+        chars_number = max
+        new_content = []
+        breakIndex = 0
+
+        for index, sentence in enumerate(self.center["content"]):
+            if chars_number <= 0:
+                break
+
+            if len(sentence) < chars_number:
+                new_content.append(sentence)
+                chars_number -= len(sentence)
+            elif len(sentence) == chars_number:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+            else:
+                new_content.append(sentence[0 : chars_number])
+                chars_number -= len(sentence)
+                breakIndex = index + 1
+
+        self.center["content"] = new_content
+        self.center["color"] = self.center["color"][0:breakIndex]
+        self.center["highlight"] = self.center["highlight"][0:breakIndex]
 
         return self
 

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -70,10 +70,10 @@ class TermSpark:
         self.spark_position("center", *contents)
 
         return self
-
-    def max_left(self, max: int):
-        if "left" in self.printed:
-            raise MaxLenNotSupported("print_left")
+    
+    def max_position(self, position: str, max: int):
+        if position in self.printed:
+            raise MaxLenNotSupported(f"print_{position}")
 
         if max < 1:
             raise MinNotReachedException("max", 1)
@@ -82,7 +82,7 @@ class TermSpark:
         new_content = []
         breakIndex = 0
 
-        for index, sentence in enumerate(self.left["content"]):
+        for index, sentence in enumerate(getattr(self, position)["content"]):
             if chars_number <= 0:
                 break
 
@@ -98,75 +98,22 @@ class TermSpark:
                 chars_number -= len(sentence)
                 breakIndex = index + 1
 
-        getattr(self, "left")["content"] = new_content
-        getattr(self, "left")["color"] = getattr(self, "left")["color"][0:breakIndex]
-        getattr(self, "left")["highlight"] = getattr(self, "left")["highlight"][0:breakIndex]
+        getattr(self, position)["content"] = new_content
+        getattr(self, position)["color"] = getattr(self, position)["color"][0:breakIndex]
+        getattr(self, position)["highlight"] = getattr(self, position)["highlight"][0:breakIndex]
+
+    def max_left(self, max: int):
+        self.max_position("left", max)
 
         return self
 
     def max_right(self, max: int):
-        if "right" in self.printed:
-            raise MaxLenNotSupported("print_right")
-
-        if max < 1:
-            raise MinNotReachedException("max", 1)
-
-        chars_number = max
-        new_content = []
-        breakIndex = 0
-
-        for index, sentence in enumerate(self.right["content"]):
-            if chars_number <= 0:
-                break
-
-            if len(sentence) < chars_number:
-                new_content.append(sentence)
-                chars_number -= len(sentence)
-            elif len(sentence) == chars_number:
-                new_content.append(sentence[0:chars_number])
-                chars_number -= len(sentence)
-                breakIndex = index + 1
-            else:
-                new_content.append(sentence[0:chars_number])
-                chars_number -= len(sentence)
-                breakIndex = index + 1
-
-        getattr(self, "right")["content"] = new_content
-        getattr(self, "right")["color"] = getattr(self, "right")["color"][0:breakIndex]
-        getattr(self, "right")["highlight"] = getattr(self, "right")["highlight"][0:breakIndex]
+        self.max_position("right", max)
 
         return self
 
     def max_center(self, max: int):
-        if "center" in self.printed:
-            raise MaxLenNotSupported("print_center")
-
-        if max < 1:
-            raise MinNotReachedException("max", 1)
-
-        chars_number = max
-        new_content = []
-        breakIndex = 0
-
-        for index, sentence in enumerate(self.center["content"]):
-            if chars_number <= 0:
-                break
-
-            if len(sentence) < chars_number:
-                new_content.append(sentence)
-                chars_number -= len(sentence)
-            elif len(sentence) == chars_number:
-                new_content.append(sentence[0:chars_number])
-                chars_number -= len(sentence)
-                breakIndex = index + 1
-            else:
-                new_content.append(sentence[0:chars_number])
-                chars_number -= len(sentence)
-                breakIndex = index + 1
-
-        getattr(self, "center")["content"] = new_content
-        getattr(self, "center")["color"] = getattr(self, "center")["color"][0:breakIndex]
-        getattr(self, "center")["highlight"] = getattr(self, "center")["highlight"][0:breakIndex]
+        self.max_position("center", max)
 
         return self
 

--- a/tests/max_len_not_supported_test.py
+++ b/tests/max_len_not_supported_test.py
@@ -1,0 +1,18 @@
+from termspark.exceptions.maxLenNotSupported import MaxLenNotSupported
+from termspark.painter.constants.fore import Fore
+
+
+class TestMaxLenNotSupported:
+    def test_exception_attributes(self):
+        exception = MaxLenNotSupported("print_left")
+        assert exception.method == "print_left"
+
+    def test_exception_dynamic_message(self):
+        exception = MaxLenNotSupported("print_right")
+        assert all(
+            word in str(exception)
+            for word in [
+                f"Max Length not supported for {exception.method}, use spark_[position] instead!",
+                str(Fore.RED),
+            ]
+        )

--- a/tests/max_length_test.py
+++ b/tests/max_length_test.py
@@ -57,6 +57,31 @@ class TestMaxLength:
         assert termspark.center["highlight"][0] == "white"
         assert termspark.center["highlight"][1] == "blue"
 
+    def test_max_length_with_single_content_first_elem_equal_to_max(self):
+        termspark = TermSpark()
+        termspark.spark_center([" CENTER ", "gray", "white"])
+        termspark.max_center(8)
+
+        assert len(termspark.center["content"]) == 1
+        assert len(termspark.center["color"]) == 1
+        assert len(termspark.center["highlight"]) == 1
+        assert termspark.center["content"][0] == " CENTER "
+        assert termspark.center["color"][0] == "gray"
+        assert termspark.center["highlight"][0] == "white"
+
+    def test_max_length_with_multiple_content_first_elem_equal_to_max(self):
+        termspark = TermSpark()
+        termspark.spark_center([" CENTER| ", "gray", "white"])
+        termspark.spark_center([" RETNER ", "white", "blue"])
+        termspark.max_center(9)
+
+        assert len(termspark.center["content"]) == 1
+        assert len(termspark.center["color"]) == 1
+        assert len(termspark.center["highlight"]) == 1
+        assert termspark.center["content"][0] == " CENTER| "
+        assert termspark.center["color"][0] == "gray"
+        assert termspark.center["highlight"][0] == "white"
+
     def test_max_length_minimum_value(self):
         termspark = TermSpark()
         termspark.spark_center([" CENTER ", "gray", "white"])

--- a/tests/max_length_test.py
+++ b/tests/max_length_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+from termspark.exceptions.minNotReachedException import MinNotReachedException
+from termspark.exceptions.maxLenNotSupported import MaxLenNotSupported
+from termspark.termspark import TermSpark
+
+
+class TestMaxLength:
+    def test_max_length_with_spark(self):
+        termspark = TermSpark()
+        termspark.spark_left(["LEFT", "red"])
+        termspark.spark_center(["CENTER", "green"])
+        termspark.spark_right(["RIGHT", "blue"])
+        termspark.max_left(2)
+        termspark.max_center(2)
+        termspark.max_right(2)
+
+        assert termspark.left["content"][0] == "LE"
+        assert termspark.center["content"][0] == "CE"
+        assert termspark.right["content"][0] == "RI"
+
+    def test_max_length_not_supported_by_print(self):
+        termspark = TermSpark()
+        termspark.spark_left(["LEFT", "red"])
+        termspark.print_right("RIGHT", "blue")
+        termspark.max_left(2)
+
+        with pytest.raises(MaxLenNotSupported):
+            termspark.max_right(2)
+
+    def test_max_length_with_multiple_content_first_elem_longer_than_max(self):
+        termspark = TermSpark()
+        termspark.spark_center([" CENTER| ", "gray", "white"])
+        termspark.spark_center([" RETNER ", "white", "blue"])
+        termspark.max_center(3)
+
+        assert len(termspark.center["content"]) == 1
+        assert len(termspark.center["color"]) == 1
+        assert len(termspark.center["highlight"]) == 1
+        assert termspark.center["content"][0] == " CE"
+        assert termspark.center["color"][0] == "gray"
+        assert termspark.center["highlight"][0] == "white"
+
+    def test_max_length_with_multiple_content_first_elem_less_than_max(self):
+        termspark = TermSpark()
+        termspark.spark_center([" CENTER| ", "gray", "white"])
+        termspark.spark_center([" RETNER ", "white", "blue"])
+        termspark.max_center(11)
+
+        assert len(termspark.center["content"]) == 2
+        assert len(termspark.center["color"]) == 2
+        assert len(termspark.center["highlight"]) == 2
+        assert termspark.center["content"][0] == " CENTER| "
+        assert termspark.center["content"][1] == " R"
+        assert termspark.center["color"][0] == "gray"
+        assert termspark.center["color"][1] == "white"
+        assert termspark.center["highlight"][0] == "white"
+        assert termspark.center["highlight"][1] == "blue"
+
+    def test_max_length_minimum_value(self):
+        termspark = TermSpark()
+        termspark.spark_center([" CENTER ", "gray", "white"])
+
+        with pytest.raises(MinNotReachedException):
+            termspark.max_center(0)

--- a/tests/max_length_test.py
+++ b/tests/max_length_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from termspark.exceptions.minNotReachedException import MinNotReachedException
 from termspark.exceptions.maxLenNotSupported import MaxLenNotSupported
+from termspark.exceptions.minNotReachedException import MinNotReachedException
 from termspark.termspark import TermSpark
 
 

--- a/tests/min_not_reached_exception_test.py
+++ b/tests/min_not_reached_exception_test.py
@@ -1,0 +1,19 @@
+from termspark.exceptions.minNotReachedException import MinNotReachedException
+from termspark.painter.constants.fore import Fore
+
+
+class TestMinNotReachedException:
+    def test_exception_attributes(self):
+        exception = MinNotReachedException("max", 1)
+        assert exception.var == "max"
+        assert exception.min == 1
+
+    def test_exception_dynamic_message(self):
+        exception = MinNotReachedException("max", 1)
+        assert all(
+            word in str(exception)
+            for word in [
+                "max must be at least 1!",
+                str(Fore.RED),
+            ]
+        )


### PR DESCRIPTION
```python
termspark = TermSpark()
termspark.spark_left(["LEFT", "red"])
termspark.spark_center(["CENTER", "green"])
termspark.spark_right(["RIGHT", "blue"])
termspark.max_left(2)
termspark.max_center(4)
termspark.max_right(3)
termspark.spark()
```

### Result
![Screenshot from 2023-11-27 22-49-52](https://github.com/faissaloux/termspark/assets/60013703/3da7f71f-51ef-45c7-8104-a697bfb37e4d)
