### PR TITLE
`full_width()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,17 @@ You can specify max width of content depending on position using `max_[position]
 This should show only "LE" on the left, and "RIG" on the right.
 > **Warning**
 > `max_[position]()` is only supported by sparkers.
+
+## Full width
+You can enable full width by using `full_width()`.
+
+```python
+    from termspark import TermSpark
+
+    termspark = TermSpark()
+    termspark.spark_center(['Thanks for using Termspark!', 'white', 'green'])
+    termspark.full_width()
+    termspark.spark()
+```
+> **Warning**
+> `full_width()` can only be used with one position.

--- a/termspark/exceptions/multiplePositionsNotSupported.py
+++ b/termspark/exceptions/multiplePositionsNotSupported.py
@@ -1,0 +1,10 @@
+import termspark.termspark
+
+
+class MultiplePositionsNotSupported(Exception):
+    def __str__(self):
+        message = termspark.TermSpark().print_left(
+            f"full_width() can only be used with one position!", "red"
+        )
+
+        return str(message)

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -245,30 +245,28 @@ class TermSpark:
 
     def take_full_width(self):
         not_empty_positions = 0
-        not_empty_position = None
+        active_position = None
 
         for position in self.positions:
             if "content" in getattr(self, position):
-                not_empty_position = position
+                active_position = position
                 not_empty_positions += 1
 
         if not_empty_positions > 1:
             raise MultiplePositionsNotSupported()
 
         empty_space = self.get_width() - len(
-            "".join(getattr(self, not_empty_position)["content"])
+            "".join(getattr(self, active_position)["content"])
         )
 
-        if isinstance(getattr(self, not_empty_position)["content"], list):
-            if not_empty_position == "left":
-                getattr(self, not_empty_position)["content"][-1] = (
-                    getattr(self, not_empty_position)["content"][-1] + " " * empty_space
-                )
-            elif not_empty_position == "right":
-                getattr(self, not_empty_position)["content"][0] = (
-                    " " * empty_space + getattr(self, not_empty_position)["content"][0]
-                )
-            else:
+        match active_position:
+            case "left":
+                extra_left_space = ""
+                extra_right_space = " " * empty_space
+            case "right":
+                extra_left_space = " " * empty_space
+                extra_right_space = ""
+            case "center":
                 half_empty_space = empty_space // 2
 
                 extra_left_space = " " * half_empty_space
@@ -278,34 +276,20 @@ class TermSpark:
                     else " " * half_empty_space
                 )
 
-                getattr(self, not_empty_position)["content"][0] = (
-                    extra_left_space
-                    + getattr(self, not_empty_position)["content"][0]
-                    + extra_right_space
-                )
+        if isinstance(getattr(self, active_position)["content"], list):
+            getattr(self, active_position)["content"][0] = (
+                extra_left_space
+                + getattr(self, active_position)["content"][0]
+            )
+
+            getattr(self, active_position)["content"][-1] = (
+                getattr(self, active_position)["content"][-1]
+                + extra_right_space
+            )
         else:
-            if not_empty_position == "left":
-                getattr(self, not_empty_position)["content"] = (
-                    getattr(self, not_empty_position)["content"] + " " * empty_space
-                )
-            elif not_empty_position == "right":
-                getattr(self, not_empty_position)["content"] = (
-                    " " * empty_space + getattr(self, not_empty_position)["content"]
-                )
-            else:
-                half_empty_space = empty_space // 2
-
-                extra_left_space = " " * half_empty_space
-                extra_right_space = (
-                    " " * (half_empty_space + 1)
-                    if empty_space % 2 != 0
-                    else " " * half_empty_space
-                )
-                getattr(self, not_empty_position)["content"] = (
-                    extra_left_space
-                    + getattr(self, not_empty_position)["content"]
-                    + extra_right_space
-                )
+            getattr(self, active_position)["content"] = (
+                extra_left_space + getattr(self, active_position)["content"] + extra_right_space
+            )
 
     def render(self) -> str:
         self.paint_content()

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -5,9 +5,9 @@ from typing import Dict, List, Optional
 from .exceptions.argCharsExceededException import ArgCharsExceededException
 from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .exceptions.minNotReachedException import MinNotReachedException
+from .exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 from .exceptions.printerArgException import PrinterArgException
 from .exceptions.printerSparkerMixException import PrinterSparkerMixException
-from .exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 from .helpers.existenceChecker import ExistenceChecker
 from .painter.painter import Painter
 from .structurer.structurer import Structurer
@@ -177,7 +177,7 @@ class TermSpark:
         self.width = width
 
         return self
-    
+
     def full_width(self):
         self.is_full_width = True
 
@@ -242,44 +242,70 @@ class TermSpark:
             self.width = self.get_terminal_width()
 
         return self.width
-    
+
     def take_full_width(self):
         not_empty_positions = 0
         not_empty_position = None
 
         for position in self.positions:
-            if 'content' in getattr(self, position):
+            if "content" in getattr(self, position):
                 not_empty_position = position
                 not_empty_positions += 1
 
         if not_empty_positions > 1:
             raise MultiplePositionsNotSupported()
 
-        empty_space = self.get_width() - len("".join(getattr(self, not_empty_position)["content"]))
+        empty_space = self.get_width() - len(
+            "".join(getattr(self, not_empty_position)["content"])
+        )
 
         if isinstance(getattr(self, not_empty_position)["content"], list):
-            if not_empty_position == 'left':
-                getattr(self, not_empty_position)["content"][-1] = getattr(self, not_empty_position)["content"][-1] + ' ' * empty_space
-            elif not_empty_position == 'right':
-                getattr(self, not_empty_position)["content"][0] = ' ' * empty_space + getattr(self, not_empty_position)["content"][0]
+            if not_empty_position == "left":
+                getattr(self, not_empty_position)["content"][-1] = (
+                    getattr(self, not_empty_position)["content"][-1] + " " * empty_space
+                )
+            elif not_empty_position == "right":
+                getattr(self, not_empty_position)["content"][0] = (
+                    " " * empty_space + getattr(self, not_empty_position)["content"][0]
+                )
             else:
                 half_empty_space = empty_space // 2
 
-                extra_left_space = ' ' * half_empty_space
-                extra_right_space = ' ' * (half_empty_space + 1) if empty_space % 2 != 0 else ' ' * half_empty_space
+                extra_left_space = " " * half_empty_space
+                extra_right_space = (
+                    " " * (half_empty_space + 1)
+                    if empty_space % 2 != 0
+                    else " " * half_empty_space
+                )
 
-                getattr(self, not_empty_position)["content"][0] = extra_left_space + getattr(self, not_empty_position)["content"][0] + extra_right_space
+                getattr(self, not_empty_position)["content"][0] = (
+                    extra_left_space
+                    + getattr(self, not_empty_position)["content"][0]
+                    + extra_right_space
+                )
         else:
-            if not_empty_position == 'left':
-                getattr(self, not_empty_position)["content"] = getattr(self, not_empty_position)["content"] + ' ' * empty_space
-            elif not_empty_position == 'right':
-                getattr(self, not_empty_position)["content"] = ' ' * empty_space + getattr(self, not_empty_position)["content"]
+            if not_empty_position == "left":
+                getattr(self, not_empty_position)["content"] = (
+                    getattr(self, not_empty_position)["content"] + " " * empty_space
+                )
+            elif not_empty_position == "right":
+                getattr(self, not_empty_position)["content"] = (
+                    " " * empty_space + getattr(self, not_empty_position)["content"]
+                )
             else:
                 half_empty_space = empty_space // 2
-                
-                extra_left_space = ' ' * half_empty_space
-                extra_right_space = ' ' * (half_empty_space + 1) if empty_space % 2 != 0 else ' ' * half_empty_space
-                getattr(self, not_empty_position)["content"] = extra_left_space + getattr(self, not_empty_position)["content"] + extra_right_space
+
+                extra_left_space = " " * half_empty_space
+                extra_right_space = (
+                    " " * (half_empty_space + 1)
+                    if empty_space % 2 != 0
+                    else " " * half_empty_space
+                )
+                getattr(self, not_empty_position)["content"] = (
+                    extra_left_space
+                    + getattr(self, not_empty_position)["content"]
+                    + extra_right_space
+                )
 
     def render(self) -> str:
         self.paint_content()

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -7,6 +7,7 @@ from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .exceptions.minNotReachedException import MinNotReachedException
 from .exceptions.printerArgException import PrinterArgException
 from .exceptions.printerSparkerMixException import PrinterSparkerMixException
+from .exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 from .helpers.existenceChecker import ExistenceChecker
 from .painter.painter import Painter
 from .structurer.structurer import Structurer
@@ -20,6 +21,7 @@ class TermSpark:
     center: Dict[str, str] = {}
     separator: str = " "
     line_is_set: bool = False
+    is_full_width: bool = False
     printed: List[str] = []
     colors: chain = chain(range(30, 37), range(90, 97))
     highlights: chain = chain(range(41, 47), range(100, 108))
@@ -175,6 +177,11 @@ class TermSpark:
         self.width = width
 
         return self
+    
+    def full_width(self):
+        self.is_full_width = True
+
+        return self
 
     def calculate_separator_length(self):
         colors_codes_length = self.calculate_colors_codes_length()
@@ -235,6 +242,44 @@ class TermSpark:
             self.width = self.get_terminal_width()
 
         return self.width
+    
+    def take_full_width(self):
+        not_empty_positions = 0
+        not_empty_position = None
+
+        for position in self.positions:
+            if 'content' in getattr(self, position):
+                not_empty_position = position
+                not_empty_positions += 1
+
+        if not_empty_positions > 1:
+            raise MultiplePositionsNotSupported()
+
+        empty_space = self.get_width() - len("".join(getattr(self, not_empty_position)["content"]))
+
+        if isinstance(getattr(self, not_empty_position)["content"], list):
+            if not_empty_position == 'left':
+                getattr(self, not_empty_position)["content"][-1] = getattr(self, not_empty_position)["content"][-1] + ' ' * empty_space
+            elif not_empty_position == 'right':
+                getattr(self, not_empty_position)["content"][0] = ' ' * empty_space + getattr(self, not_empty_position)["content"][0]
+            else:
+                half_empty_space = empty_space // 2
+
+                extra_left_space = ' ' * half_empty_space
+                extra_right_space = ' ' * (half_empty_space + 1) if empty_space % 2 != 0 else ' ' * half_empty_space
+
+                getattr(self, not_empty_position)["content"][0] = extra_left_space + getattr(self, not_empty_position)["content"][0] + extra_right_space
+        else:
+            if not_empty_position == 'left':
+                getattr(self, not_empty_position)["content"] = getattr(self, not_empty_position)["content"] + ' ' * empty_space
+            elif not_empty_position == 'right':
+                getattr(self, not_empty_position)["content"] = ' ' * empty_space + getattr(self, not_empty_position)["content"]
+            else:
+                half_empty_space = empty_space // 2
+                
+                extra_left_space = ' ' * half_empty_space
+                extra_right_space = ' ' * (half_empty_space + 1) if empty_space % 2 != 0 else ' ' * half_empty_space
+                getattr(self, not_empty_position)["content"] = extra_left_space + getattr(self, not_empty_position)["content"] + extra_right_space
 
     def render(self) -> str:
         self.paint_content()
@@ -312,7 +357,7 @@ class TermSpark:
                         if chars_number_left > 0:
                             if len(content) > chars_number_left:
                                 new_content.append(
-                                    content[0 : len(content) - chars_number_left]
+                                    content[0 : len(content) - chars_number_left - 1]
                                 )
                                 chars_number_left -= chars_number
                             else:
@@ -346,6 +391,8 @@ class TermSpark:
             self.trim(to_trim)
         else:
             self.mode = "color"
+            if self.is_full_width:
+                self.take_full_width()
             print(self.render(), end=end)
 
     def raw(self) -> str:

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -278,17 +278,17 @@ class TermSpark:
 
         if isinstance(getattr(self, active_position)["content"], list):
             getattr(self, active_position)["content"][0] = (
-                extra_left_space
-                + getattr(self, active_position)["content"][0]
+                extra_left_space + getattr(self, active_position)["content"][0]
             )
 
             getattr(self, active_position)["content"][-1] = (
-                getattr(self, active_position)["content"][-1]
-                + extra_right_space
+                getattr(self, active_position)["content"][-1] + extra_right_space
             )
         else:
             getattr(self, active_position)["content"] = (
-                extra_left_space + getattr(self, active_position)["content"] + extra_right_space
+                extra_left_space
+                + getattr(self, active_position)["content"]
+                + extra_right_space
             )
 
     def render(self) -> str:

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -259,22 +259,21 @@ class TermSpark:
             "".join(getattr(self, active_position)["content"])
         )
 
-        match active_position:
-            case "left":
-                extra_left_space = ""
-                extra_right_space = " " * empty_space
-            case "right":
-                extra_left_space = " " * empty_space
-                extra_right_space = ""
-            case "center":
-                half_empty_space = empty_space // 2
+        if active_position == "left":
+            extra_left_space = ""
+            extra_right_space = " " * empty_space
+        elif active_position == "right":
+            extra_left_space = " " * empty_space
+            extra_right_space = ""
+        else:
+            half_empty_space = empty_space // 2
 
-                extra_left_space = " " * half_empty_space
-                extra_right_space = (
-                    " " * (half_empty_space + 1)
-                    if empty_space % 2 != 0
-                    else " " * half_empty_space
-                )
+            extra_left_space = " " * half_empty_space
+            extra_right_space = (
+                " " * (half_empty_space + 1)
+                if empty_space % 2 != 0
+                else " " * half_empty_space
+            )
 
         if isinstance(getattr(self, active_position)["content"], list):
             getattr(self, active_position)["content"][0] = (

--- a/tests/full_width_test.py
+++ b/tests/full_width_test.py
@@ -1,6 +1,9 @@
 import pytest
+
+from termspark.exceptions.multiplePositionsNotSupported import (
+    MultiplePositionsNotSupported,
+)
 from termspark.termspark import TermSpark
-from termspark.exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 
 
 class TestRaw:

--- a/tests/full_width_test.py
+++ b/tests/full_width_test.py
@@ -1,0 +1,66 @@
+import pytest
+from termspark.termspark import TermSpark
+from termspark.exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
+
+
+class TestRaw:
+    def test_is_full_width(self):
+        termspark = TermSpark().print_left("LEFT", "red")
+        termspark.full_width()
+
+        assert termspark.is_full_width == True
+
+    def test_full_width_does_not_accept_multiple_positions(self):
+        termspark = TermSpark().spark_left("LEFT", "red").spark_right("RIGHT", "blue")
+        termspark.full_width()
+
+        with pytest.raises(MultiplePositionsNotSupported):
+            termspark.spark()
+
+    def test_is_full_width_with_spark_left(self):
+        termspark = TermSpark().spark_left(["LEFT", "white", "blue"])
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.left["content"][0]) == termspark.get_terminal_width()
+
+    def test_is_full_width_with_spark_center(self):
+        termspark = TermSpark().spark_center(["CENTER", "white", "blue"])
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.center["content"][0]) == termspark.get_terminal_width()
+
+    def test_is_full_width_with_spark_right(self):
+        termspark = TermSpark().spark_right(["RIGHT", "white", "blue"])
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.right["content"][0]) == termspark.get_terminal_width()
+
+    def test_is_full_width_with_print_left(self):
+        termspark = TermSpark().print_left("LEFT", "white", "blue")
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.left["content"]) == termspark.get_terminal_width()
+
+    def test_is_full_width_with_print_center(self):
+        termspark = TermSpark().print_center("CENTER", "white", "blue")
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.center["content"]) == termspark.get_terminal_width()
+
+    def test_is_full_width_with_print_right(self):
+        termspark = TermSpark().print_right("RIGHT", "white", "blue")
+        termspark.full_width()
+        termspark.spark()
+
+        assert termspark.is_full_width == True
+        assert len(termspark.right["content"]) == termspark.get_terminal_width()

--- a/tests/multiple_positions_not_supported_exception_test.py
+++ b/tests/multiple_positions_not_supported_exception_test.py
@@ -1,0 +1,14 @@
+from termspark.exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
+from termspark.painter.constants.fore import Fore
+
+
+class TestMultiplePositionsNotSupportedException:
+    def test_exception_message(self):
+        exception = MultiplePositionsNotSupported()
+        assert all(
+            word in str(exception)
+            for word in [
+                "full_width() can only be used with one position!",
+                str(Fore.RED),
+            ]
+        )

--- a/tests/multiple_positions_not_supported_exception_test.py
+++ b/tests/multiple_positions_not_supported_exception_test.py
@@ -1,4 +1,6 @@
-from termspark.exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
+from termspark.exceptions.multiplePositionsNotSupported import (
+    MultiplePositionsNotSupported,
+)
 from termspark.painter.constants.fore import Fore
 
 


### PR DESCRIPTION
Add ability to take full width by position content using `full_width()`

```python
termspark = TermSpark()
termspark.spark_center(['Thanks for using Termspark!', 'white', 'green'])
termspark.full_width()
termspark.spark()
````

### Result
![Screenshot from 2023-11-28 22-24-23](https://github.com/faissaloux/termspark/assets/60013703/6a1e0df6-ce88-4609-80c9-41d725d9e166)
