### PR TITLE
Ability to paint a line

### DIFF
--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -218,8 +218,8 @@ class TermSpark:
 
         return colors_codes_length - len("\x1b")
 
-    def line(self, separator: Optional[str] = None):
-        self.set_separator(separator if separator else self.separator["content"])
+    def line(self, separator: Optional[str] = None, highlight: Optional[str] = None):
+        self.set_separator(separator if separator else self.separator["content"], highlight=highlight)
         self.line_is_set = True
 
         return self

--- a/tests/termspark_attributes_test.py
+++ b/tests/termspark_attributes_test.py
@@ -64,3 +64,16 @@ class TestTermsparkAttributes:
         assert termspark.separator["content"] == "."
         assert termspark.separator["color"] == ""  # Default
         assert termspark.separator["highlight"] == ""  # Default
+
+    def test_can_set_line_with_highlight(self):
+        termspark = TermSpark()
+        assert termspark.line_is_set == False
+        assert termspark.separator["content"] == " "  # Default
+        assert termspark.separator["color"] == ""  # Default
+        assert termspark.separator["highlight"] == ""  # Default
+
+        termspark.line(highlight='green')
+        assert termspark.line_is_set == True
+        assert termspark.separator["content"] == " "  # Default
+        assert termspark.separator["color"] == ""  # Default
+        assert termspark.separator["highlight"] == "green"

--- a/tests/termspark_return_test.py
+++ b/tests/termspark_return_test.py
@@ -282,6 +282,12 @@ class TestTermsparkReturn:
         terminal_width = termspark.get_terminal_width()
         assert str(termspark) == "." * (terminal_width - len("\x1b"))
 
+    def test_customized_line_with_highlight(self):
+        termspark = TermSpark().line(".", "green")
+
+        terminal_width = termspark.get_terminal_width()
+        assert str(termspark) == "\x1b[42m.\x1b[0m" * (terminal_width - len("\x1b"))
+
     def test_force_width(self):
         width = 100
         termspark = TermSpark().set_width(width).line(".")


### PR DESCRIPTION
This PR allows to paint a line by passing `highlight` to `line()`.

```python
termspark = TermSpark()
termspark.line(highlight='green')
termspark.spark()
```

### Result
![Screenshot from 2023-11-30 01-20-15](https://github.com/faissaloux/termspark/assets/60013703/41be7d15-4cab-4f73-a460-89c6d254db78)
