### PR TITLE
Separator can accept only 1 character

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 ```
 
 > **Note**
-> Separator can contain only one character max.
+> Separator can contain only one character.
 
 ## You can also paint your content
 

--- a/termspark/exceptions/lenNotSupportedException.py
+++ b/termspark/exceptions/lenNotSupportedException.py
@@ -1,0 +1,14 @@
+import termspark.termspark
+
+
+class LenNotSupportedException(Exception):
+    def __init__(self, var: str, length: int):
+        self.var = var
+        self.length = length
+
+    def __str__(self):
+        message = termspark.TermSpark().print_left(
+            f"{self.var} must contain {self.length} character!",
+            "red",
+        )
+        return str(message)

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -2,9 +2,8 @@ import os
 from itertools import chain
 from typing import Dict, List, Optional
 
-from .exceptions.argCharsExceededException import ArgCharsExceededException
-from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .exceptions.lenNotSupportedException import LenNotSupportedException
+from .exceptions.maxLenNotSupported import MaxLenNotSupported
 from .exceptions.minNotReachedException import MinNotReachedException
 from .exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 from .exceptions.printerArgException import PrinterArgException

--- a/termspark/termspark.py
+++ b/termspark/termspark.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 
 from .exceptions.argCharsExceededException import ArgCharsExceededException
 from .exceptions.maxLenNotSupported import MaxLenNotSupported
+from .exceptions.lenNotSupportedException import LenNotSupportedException
 from .exceptions.minNotReachedException import MinNotReachedException
 from .exceptions.multiplePositionsNotSupported import MultiplePositionsNotSupported
 from .exceptions.printerArgException import PrinterArgException
@@ -173,8 +174,8 @@ class TermSpark:
     def set_separator(
         self, content: str, color: Optional[str] = None, highlight: Optional[str] = None
     ):
-        if len(content) > 1:
-            raise ArgCharsExceededException("separator", "one")
+        if len(content) != 1:
+            raise LenNotSupportedException("separator", 1)
 
         self.separator = Structurer(content, color, highlight).form()
 

--- a/tests/len_not_supported_exception_test.py
+++ b/tests/len_not_supported_exception_test.py
@@ -1,0 +1,19 @@
+from termspark.exceptions.lenNotSupportedException import LenNotSupportedException
+from termspark.painter.constants.fore import Fore
+
+
+class TestLenNotSupportedException:
+    def test_exception_attributes(self):
+        exception = LenNotSupportedException("separator", 1)
+        assert exception.var == "separator"
+        assert exception.length == 1
+
+    def test_exception_dynamic_message(self):
+        exception = LenNotSupportedException("separator", 1)
+        assert all(
+            word in str(exception)
+            for word in [
+                f"{exception.var} must contain {exception.length} character!",
+                str(Fore.RED),
+            ]
+        )

--- a/tests/termspark_attributes_test.py
+++ b/tests/termspark_attributes_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from termspark.exceptions.argCharsExceededException import ArgCharsExceededException
+from termspark.exceptions.lenNotSupportedException import LenNotSupportedException
 from termspark.termspark import TermSpark
 
 
@@ -16,11 +16,19 @@ class TestTermsparkAttributes:
         assert termspark.separator["color"] == ""  # Default
         assert termspark.separator["highlight"] == ""  # Default
 
+    def test_cant_set_more_empty_char_separator(self):
+        termspark = TermSpark()
+        assert termspark.separator["content"] == " "  # Default
+
+        with pytest.raises(LenNotSupportedException):
+            termspark.set_separator("")
+        assert termspark.separator["content"] == " "  # Default
+
     def test_cant_set_more_than_one_char_separator(self):
         termspark = TermSpark()
         assert termspark.separator["content"] == " "  # Default
 
-        with pytest.raises(ArgCharsExceededException):
+        with pytest.raises(LenNotSupportedException):
             termspark.set_separator("..")
         assert termspark.separator["content"] == " "  # Default
 


### PR DESCRIPTION
`set_separator()`  can accept only one character as content.