### PR TITLE
`print()`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ dev =
     pre-commit==3.2.0
     isort==5.11.5
     black==23.11.0
+    mock==5.1.0
+    types-mock==5.1.0
 docs =
     mkdocs==1.4.2
     mkdocs-material==9.0.15

--- a/termspark/__init__.py
+++ b/termspark/__init__.py
@@ -17,6 +17,7 @@ def print(
     highlight: Optional[str] = None,
     style: Optional[str] = None,
     position: str = "left",
+    full_width: bool = False,
 ) -> None:
     if content is None:
         content = ""
@@ -25,6 +26,9 @@ def print(
 
     if not hasattr(termspark, f"spark_{position}"):
         raise PositionNotSupportedException(position)
+
+    if full_width:
+        termspark.full_width()
 
     spark = getattr(termspark, f"spark_{position}")
 

--- a/termspark/__init__.py
+++ b/termspark/__init__.py
@@ -13,11 +13,10 @@ def print(
     color: Optional[str] = None,
     highlight: Optional[str] = None,
     style: Optional[str] = None,
-    end: str = "\n",
 ) -> None:
     if content is None:
         content = ""
 
     termspark = TermSpark()
-    termspark.print_left(content, color, highlight, style)
-    termspark.spark(end)
+    termspark.spark_left([content, color, highlight, style])  # type: ignore
+    termspark.spark()

--- a/termspark/__init__.py
+++ b/termspark/__init__.py
@@ -2,6 +2,9 @@ import os
 import sys
 from typing import Optional
 
+from termspark.exceptions.positionNotSupportedException import (
+    PositionNotSupportedException,
+)
 from termspark.termspark import TermSpark
 
 if sys.platform == "win32":  # codecov-ignore
@@ -13,10 +16,17 @@ def print(
     color: Optional[str] = None,
     highlight: Optional[str] = None,
     style: Optional[str] = None,
+    position: str = "left",
 ) -> None:
     if content is None:
         content = ""
 
     termspark = TermSpark()
-    termspark.spark_left([content, color, highlight, style])  # type: ignore
+
+    if not hasattr(termspark, f"spark_{position}"):
+        raise PositionNotSupportedException(position)
+
+    spark = getattr(termspark, f"spark_{position}")
+
+    spark([content, color, highlight, style])  # type: ignore
     termspark.spark()

--- a/termspark/__init__.py
+++ b/termspark/__init__.py
@@ -1,7 +1,23 @@
 import os
 import sys
+from typing import Optional
 
 from termspark.termspark import TermSpark
 
 if sys.platform == "win32":  # codecov-ignore
     os.system("color")
+
+
+def print(
+    content: Optional[str] = None,
+    color: Optional[str] = None,
+    highlight: Optional[str] = None,
+    style: Optional[str] = None,
+    end: str = "\n",
+) -> None:
+    if content is None:
+        content = ""
+
+    termspark = TermSpark()
+    termspark.print_left(content, color, highlight, style)
+    termspark.spark(end)

--- a/termspark/exceptions/positionNotSupportedException.py
+++ b/termspark/exceptions/positionNotSupportedException.py
@@ -1,0 +1,13 @@
+import termspark.termspark
+
+
+class PositionNotSupportedException(Exception):
+    def __init__(self, position: str):
+        self.position = position
+
+    def __str__(self):
+        message = termspark.TermSpark().print_left(
+            f"{self.position} position is not supported!",
+            "red",
+        )
+        return str(message)

--- a/tests/position_not_supported_exception_test.py
+++ b/tests/position_not_supported_exception_test.py
@@ -1,0 +1,20 @@
+from termspark.exceptions.positionNotSupportedException import (
+    PositionNotSupportedException,
+)
+from termspark.painter.constants.fore import Fore
+
+
+class TestPositionNotSupportedException:
+    def test_exception_attributes(self):
+        exception = PositionNotSupportedException("not_supported")
+        assert exception.position == "not_supported"
+
+    def test_exception_dynamic_message(self):
+        exception = PositionNotSupportedException("not_supported")
+        assert all(
+            word in str(exception)
+            for word in [
+                f"{exception.position} position is not supported!",
+                str(Fore.RED),
+            ]
+        )

--- a/tests/print_test.py
+++ b/tests/print_test.py
@@ -1,12 +1,16 @@
+import pytest
 from mock import patch  # type: ignore
 
 from termspark import print
+from termspark.exceptions.positionNotSupportedException import (
+    PositionNotSupportedException,
+)
 
 
 class TestPrint:
     @patch("termspark.termspark.TermSpark.spark")
     @patch("termspark.termspark.TermSpark.spark_left")
-    def test_print_calls_spark_left(self, spark_left, spark):
+    def test_print_calls_spark_left_as_default(self, spark_left, spark):
         print("Termspark")
 
         spark_left.assert_called_once_with(["Termspark", None, None, None])
@@ -37,3 +41,17 @@ class TestPrint:
             ["Termspark", "white", "blue", "italic, bold"]
         )
         spark.assert_called_once_with()
+
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_right")
+    def test_print_with_position(self, spark_right, spark):
+        print("Termspark", "white", "blue", "italic, bold", position="right")
+
+        spark_right.assert_called_once_with(
+            ["Termspark", "white", "blue", "italic, bold"]
+        )
+        spark.assert_called_once_with()
+
+    def test_print_raise_exception_on_unsupported_position(self):
+        with pytest.raises(PositionNotSupportedException):
+            print("Termspark", "white", "blue", "italic, bold", position="unsupported")

--- a/tests/print_test.py
+++ b/tests/print_test.py
@@ -55,3 +55,22 @@ class TestPrint:
     def test_print_raise_exception_on_unsupported_position(self):
         with pytest.raises(PositionNotSupportedException):
             print("Termspark", "white", "blue", "italic, bold", position="unsupported")
+
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_right")
+    @patch("termspark.termspark.TermSpark.full_width")
+    def test_print_with_full_width(self, full_width, spark_right, spark):
+        print(
+            "Termspark",
+            "white",
+            "blue",
+            "italic, bold",
+            position="right",
+            full_width=True,
+        )
+
+        full_width.assert_called_once_with()
+        spark_right.assert_called_once_with(
+            ["Termspark", "white", "blue", "italic, bold"]
+        )
+        spark.assert_called_once_with()

--- a/tests/print_test.py
+++ b/tests/print_test.py
@@ -1,0 +1,39 @@
+from mock import patch  # type: ignore
+
+from termspark import print
+
+
+class TestPrint:
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_left")
+    def test_print_calls_spark_left(self, spark_left, spark):
+        print("Termspark")
+
+        spark_left.assert_called_once_with(["Termspark", None, None, None])
+        spark.assert_called_once_with()
+
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_left")
+    def test_print_with_no_content(self, spark_left, spark):
+        print()
+
+        spark_left.assert_called_once_with(["", None, None, None])
+        spark.assert_called_once_with()
+
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_left")
+    def test_print_with_some_parameters(self, spark_left, spark):
+        print("Termspark", "white", style="italic, bold")
+
+        spark_left.assert_called_once_with(["Termspark", "white", None, "italic, bold"])
+        spark.assert_called_once_with()
+
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_left")
+    def test_print_with_all_parameters(self, spark_left, spark):
+        print("Termspark", "white", "blue", "italic, bold")
+
+        spark_left.assert_called_once_with(
+            ["Termspark", "white", "blue", "italic, bold"]
+        )
+        spark.assert_called_once_with()


### PR DESCRIPTION
print with colors, highlights, styles, and hyperlinks.

With `print(position=)` you can specify position where to print `["left", "center", "right"]`.
With `print(full_width=)` you can enable full width `True | False`.

```python
from termspark import print

print(" Termspark ", "white", "blue", "italic")
print(" [@termspark](https://github.com/termspark) ", "black", "white", "italic, bold")
```

### Result
![image](https://github.com/faissaloux/termspark/assets/60013703/2fcdf8c7-dca6-4bb7-9557-e307173c5ab2)
