### PR TITLE
Fix can't print function call

### DIFF
--- a/termspark/structurer/structurer.py
+++ b/termspark/structurer/structurer.py
@@ -31,7 +31,7 @@ class Structurer:
 
     def form(self) -> Form:
         return {
-            "content": self.content,
+            "content": str(self.content),
             "color": self.color,
             "highlight": self.highlight,
             "style": self.style,

--- a/tests/structurer_test.py
+++ b/tests/structurer_test.py
@@ -38,3 +38,8 @@ class TestStructurer:
         assert structurer.get("highlight") == "yellow"
         assert structurer.get("style") == ["bold", "underline"]
         assert structurer.get("styled_content") == "content"
+
+    def test_structure_returns_string_content(self):
+        structurer = Structurer(24).form()
+
+        assert structurer.get("content") == "24"

--- a/tests/termspark_return_test.py
+++ b/tests/termspark_return_test.py
@@ -379,3 +379,12 @@ class TestTermsparkReturn:
             + "\x1b\\"
             + " "
         )
+
+    def test_spark_supports_function_call(self):
+        termspark = TermSpark().print_left(len("TERMSPARK")).set_separator(".")
+
+        terminal_width = termspark.get_terminal_width()
+        content_space = len("9")
+        rest_space = terminal_width - content_space
+
+        assert str(termspark) == "9" + "." * rest_space


### PR DESCRIPTION
```python
from termspark import print

print(type("HEY"), "white", "blue")
```