### PR TITLE
Fix module not found and typing-extensions not installed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ termspark = py.typed
 include_package_data = true
 python_requires = >=3.8, <4
 packages=find:
+install_requires =
+    typing-extensions==4.9.0
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
`ModuleNotFoundError: No module named 'termspark.text_styler.constants'`