### PR TITLE
`print()` and `input()` separator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ You can choose from `["left", "center", "right"]` to specify where to print by p
 You can enable the Full Width using full_width parameter:
 `print(" Termspark ", highlight="blue", full_width=True)`.
 
+You can fill the empty space by a character using `print(separator=)`.
+
+```python
+from termspark import print
+
+print(" TERMSPARK ", "white", "green", position="center", separator="_")
+```
+![](https://github.com/faissaloux/termspark/assets/60013703/b6c38ae1-ec25-4abb-a078-1309c3234a62)
+
 ### `input()`
 
 input with colors, highlights, styles, and hyperlinks.
@@ -66,6 +75,15 @@ def age_calc(birthyear, currentyear=2023):
 age = input(" Your year birth? ", "white", "blue", type=int, callback=age_calc)
 print(f"Your age is: {age}")
 ```
+
+You can use separator in `input(separator=)` too.
+
+```python
+from termspark import input
+
+name = input(" What's your name?", "white", "blue", position="left", separator=".")
+```
+![](https://github.com/faissaloux/termspark/assets/60013703/b4a4f5b0-ff55-4079-8a82-a6c5a0ba0973)
 
 ### `line()`
 To print empty line use `line()`, you can leave it empty or fill it with a repeated character, you can specify its color too.

--- a/termspark/__init__.py
+++ b/termspark/__init__.py
@@ -18,6 +18,7 @@ def print(
     highlight: Optional[str] = None,
     style: Optional[str] = None,
     position: str = "left",
+    separator: Optional[str] = None,
     full_width: bool = False,
 ) -> None:
     if content is None:
@@ -27,6 +28,9 @@ def print(
 
     if not hasattr(termspark, f"spark_{position}"):
         raise PositionNotSupportedError(position)
+
+    if separator:
+        termspark.set_separator(separator)
 
     if full_width:
         termspark.full_width()
@@ -51,6 +55,7 @@ def input(
     position: str = "left",
     full_width: bool = False,
     type: builtinType = str,
+    separator: Optional[str] = None,
     callback: Callable = lambda prompt: prompt,
 ):
     if builtinType(type) != builtinType:
@@ -61,7 +66,7 @@ def input(
             "print", "callback", builtinType(type), types.FunctionType
         )
 
-    print(prompt, color, highlight, style, position, full_width)
+    print(prompt, color, highlight, style, position, separator, full_width)
 
     scaned = type(sys.stdin.readline().rstrip("\n"))
 

--- a/tests/input_test.py
+++ b/tests/input_test.py
@@ -13,7 +13,7 @@ class TestInput:
     ):
         input()
 
-        print.assert_called_once_with(None, None, None, None, "left", False)
+        print.assert_called_once_with(None, None, None, None, "left", None, False)
         readline.assert_called_once_with()
 
     @patch("sys.stdin.readline")
@@ -22,7 +22,7 @@ class TestInput:
         input(" Enter your name: ")
 
         print.assert_called_once_with(
-            " Enter your name: ", None, None, None, "left", False
+            " Enter your name: ", None, None, None, "left", None, False
         )
         readline.assert_called_once_with()
 
@@ -32,7 +32,7 @@ class TestInput:
         input(" Enter your name: ", "blue")
 
         print.assert_called_once_with(
-            " Enter your name: ", "blue", None, None, "left", False
+            " Enter your name: ", "blue", None, None, "left", None, False
         )
         readline.assert_called_once_with()
 
@@ -42,7 +42,7 @@ class TestInput:
         input(" Enter your name: ", "white", "blue")
 
         print.assert_called_once_with(
-            " Enter your name: ", "white", "blue", None, "left", False
+            " Enter your name: ", "white", "blue", None, "left", None, False
         )
         readline.assert_called_once_with()
 
@@ -52,7 +52,7 @@ class TestInput:
         input(" Enter your name: ", "white", "blue", "italic, bold")
 
         print.assert_called_once_with(
-            " Enter your name: ", "white", "blue", "italic, bold", "left", False
+            " Enter your name: ", "white", "blue", "italic, bold", "left", None, False
         )
         readline.assert_called_once_with()
 
@@ -62,7 +62,17 @@ class TestInput:
         input(" Enter your name: ", highlight="blue", position="center")
 
         print.assert_called_once_with(
-            " Enter your name: ", None, "blue", None, "center", False
+            " Enter your name: ", None, "blue", None, "center", None, False
+        )
+        readline.assert_called_once_with()
+
+    @patch("sys.stdin.readline")
+    @patch("termspark.print")
+    def test_input_can_set_separator(self, print, readline):
+        input(" Enter your name: ", highlight="blue", position="center", separator=".")
+
+        print.assert_called_once_with(
+            " Enter your name: ", None, "blue", None, "center", ".", False
         )
         readline.assert_called_once_with()
 
@@ -74,7 +84,7 @@ class TestInput:
         )
 
         print.assert_called_once_with(
-            " Enter your name: ", None, "blue", None, "center", True
+            " Enter your name: ", None, "blue", None, "center", None, True
         )
         readline.assert_called_once_with()
 

--- a/tests/print_test.py
+++ b/tests/print_test.py
@@ -50,6 +50,25 @@ class TestPrint:
         )
         spark.assert_called_once_with()
 
+    @patch("termspark.termspark.TermSpark.spark")
+    @patch("termspark.termspark.TermSpark.spark_right")
+    @patch("termspark.termspark.TermSpark.set_separator")
+    def test_print_with_separator(self, set_separator, spark_right, spark):
+        print(
+            "Termspark",
+            "white",
+            "blue",
+            "italic, bold",
+            position="right",
+            separator=".",
+        )
+
+        set_separator.assert_called_once_with(".")
+        spark_right.assert_called_once_with(
+            ["Termspark", "white", "blue", "italic, bold"]
+        )
+        spark.assert_called_once_with()
+
     def test_print_raise_exception_on_unsupported_position(self):
         with pytest.raises(PositionNotSupportedError):
             print("Termspark", "white", "blue", "italic, bold", position="unsupported")


### PR DESCRIPTION
Add separator to `print()` and `input()` 

### Input separator
```python
from termspark import input

name = input(" What's your name?", "white", "blue", position="left", separator=".")
```
![Screenshot from 2023-12-26 20-29-36](https://github.com/faissaloux/termspark/assets/60013703/b4a4f5b0-ff55-4079-8a82-a6c5a0ba0973)

### Print separator
```python
from termspark import print

print(" TERMSPARK ", "white", "green", position="center", separator="_")
```
![Screenshot from 2023-12-26 20-31-58](https://github.com/faissaloux/termspark/assets/60013703/b6c38ae1-ec25-4abb-a078-1309c3234a62)
